### PR TITLE
Do not send content-type in response of data source deletion.

### DIFF
--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import make_response, request
+from flask import make_response, request, Response
 from flask_restful import abort
 from funcy import project
 from sqlalchemy.exc import IntegrityError
@@ -60,7 +60,7 @@ class DataSourceResource(BaseResource):
         data_source = models.DataSource.get_by_id_and_org(data_source_id, self.current_org)
         data_source.delete()
 
-        return make_response('', 204)
+        return Response(status = 204, content_type = "")
 
 
 class DataSourceListResource(BaseResource):


### PR DESCRIPTION
データソース削除のレスポンスにcontent-typeが入っていました。
content-typeでtext/htmlが指定されると、go-swaggerで作成したREST APIクライアントにconsumerを独自に定義しなければならなくなり面倒です。

また、deleteのレスポンスにはレスポンスボディが入らないため、content-typeは空になるのが筋だと思われます。